### PR TITLE
specify reverse proxy headers in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,7 @@ DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/unesco-
 
 # important for CSRF protection
 ORIGIN="http://192.168.0.1:3000"
+
+# put these in as-is for production, required for the reverse proxy setup
+PROTOCOL_HEADER=x-forwarded-proto
+HOST_HEADER=x-forwarded-host


### PR DESCRIPTION
these are required (and already in place in production), might as well have them documented
